### PR TITLE
Added delete for previous data; added timeout for deletion of room 

### DIFF
--- a/home.html
+++ b/home.html
@@ -99,7 +99,6 @@
       <td>
         <div class="btn" onclick="newRoom()">
           <span>Create New Room</span>
-          <!-- <input onclick="newRoom()" type="button" value="Create New Room"> -->
         </div>
       </td>
     </tr>

--- a/room.js
+++ b/room.js
@@ -1,6 +1,21 @@
 class Room {
   constructor(name) {
-    this.name = name; this.clients = [];
+    this.name = name;
+    this.clients = [];
+    this.deleteTimer = null;
+  }
+
+  willBeDeleted() {
+    return this.deleteTimer != null;
+  }
+
+  cancelDeletion() {
+    clearTimeout(this.deleteTimer);
+    this.deleteTimer = null;
+  }
+
+  numClients() {
+    return this.clients.length;
   }
 
   addClient(clientId) {


### PR DESCRIPTION
Previous data and room deletion are now on timeout as defined by the environment variable ROOM_KEEP_SECONDS. After ROOM_KEEP_SECONDS seconds an empty room and the previous drawing data associated with it is destroyed unless a person connects to the room. This is done mainly to prevent accidental refreshes from destroying an active room. 